### PR TITLE
fixes for filename strings containing '.' char

### DIFF
--- a/image_bbox_slicer/helpers.py
+++ b/image_bbox_slicer/helpers.py
@@ -15,7 +15,10 @@ from math import sqrt, ceil, floor
 
 
 IMG_FORMAT_LIST = ['jpg', 'jpeg', 'png', 'tiff', 'exif', 'bmp']
-
+if os.environ.get('OS','') == 'Windows_NT':
+    separator = '\\'
+else:
+    separator = '/'
 # Source : Sam Dobson
 # https://github.com/samdobson/image_slicer
 
@@ -134,18 +137,17 @@ def validate_file_names(img_src, ann_src):
     Exception
         If `img_src` and `ann_src` do not have matching image and annotation file names respectively.
     """
-    imgs = sorted(glob.glob(img_src + os.sep + '*'))
-    anns = sorted(glob.glob(ann_src + os.sep + '*.xml'))
-
+    imgs = sorted(glob.glob(img_src + separator + '*'))
+    anns = sorted(glob.glob(ann_src + separator + '*.xml'))
     imgs_filter = [True if x.split(
         '.')[-1].lower() in IMG_FORMAT_LIST else False for x in imgs]
     imgs = list(compress(imgs, imgs_filter))
 
-
-
-    imgs = [x.split(os.sep)[-1].split('.')[-2] for x in imgs]
-    anns = [x.split(os.sep)[-1].split('.')[-2] for x in anns]
-
+    imgs = [os.path.splitext(x.split(separator)[-1])[0] for x in imgs]
+    anns = [os.path.splitext(x.split(separator)[-1])[0] for x in anns]
+    #imgs = [x.split(separator)[-1].split('.')[-2] for x in imgs]
+    #anns = [x.split(separator)[-1].split('.')[-2] for x in anns]
+    print(list(set(anns) - set(imgs)))
     if not (imgs == anns):
         raise Exception(
             'Each image in `{}` must have its corresponding XML file in `{}` with the same file name.'.format(img_src, ann_src))
@@ -277,7 +279,7 @@ def save_before_after_map_csv(mapper, path):
     ----------
     None
     """
-    with open('{}{}mapper.csv'.format(path, os.sep), 'w') as f:
+    with open('{}{}mapper.csv'.format(path, separator), 'w') as f:
         f.write("old_name,new_names\n")
         for key in mapper.keys():
             f.write("%s,%s\n" % (key, ','.join(mapper[key])))
@@ -364,10 +366,10 @@ def plot_image_boxes(img_path, ann_path, file_name):
     # Checking if the file is a source image as the data type
     # Source image - string, tile images - list of strings
     if isinstance(file_name, str):
-        tree = ET.parse(ann_path + os.sep + file_name + '.xml')
+        tree = ET.parse(ann_path + separator + file_name + '.xml')
         root = tree.getroot()
 
-        im = Image.open(img_path + os.sep + file_name + '.jpg')
+        im = Image.open(img_path + separator + file_name + '.jpg')
         im = np.array(im, dtype=np.uint8)
 
         rois = []
@@ -398,10 +400,10 @@ def plot_image_boxes(img_path, ann_path, file_name):
                                sharey='row', figsize=(10, 7))
         for idx, file in enumerate(file_name):
 
-            tree = ET.parse(ann_path + os.sep + file + '.xml')
+            tree = ET.parse(ann_path + separator + file + '.xml')
             root = tree.getroot()
 
-            im = Image.open(img_path + os.sep + file + '.jpg')
+            im = Image.open(img_path + separator + file + '.jpg')
             im = np.array(im, dtype=np.uint8)
 
             rois = []

--- a/image_bbox_slicer/main.py
+++ b/image_bbox_slicer/main.py
@@ -9,6 +9,11 @@ from PIL import Image
 from pascal_voc_writer import Writer
 from image_bbox_slicer.helpers import *
 
+if os.environ.get('OS','') == 'Windows_NT':
+    separator = '\\'
+else:
+    separator = '/'
+
 class Slicer(object):
     """
     Slicer class.
@@ -214,9 +219,9 @@ class Slicer(object):
         mapper = {}
         img_no = 1
 
-        for file in sorted(glob.glob(self.IMG_SRC + os.sep + "*")):
-            file_name = file.split(os.sep)[-1].split('.')[0]
-            file_type = file.split(os.sep)[-1].split('.')[-1].lower()
+        for file in sorted(glob.glob(self.IMG_SRC + separator + "*")):
+            file_name = file.split(separator)[-1].split('.')[0]
+            file_type = file.split(separator)[-1].split('.')[-1].lower()
             if file_type.lower() not in IMG_FORMAT_LIST:
                 continue
             im = Image.open(file)
@@ -238,7 +243,7 @@ class Slicer(object):
                         self._ignore_tiles.remove(img_id_str)
                         continue
                 new_im.save(
-                    '{}{}{}.{}'.format(self.IMG_DST, os.sep, img_id_str, file_type))
+                    '{}{}{}.{}'.format(self.IMG_DST, separator, img_id_str, file_type))
                 new_ids.append(img_id_str)
                 img_no += 1
             mapper[file_name] = new_ids
@@ -294,12 +299,12 @@ class Slicer(object):
         mapper = {}
         empty_count = 0
 
-        for xml_file in sorted(glob.glob(self.ANN_SRC + os.sep + '*.xml')):
+        for xml_file in sorted(glob.glob(self.ANN_SRC + separator + '*.xml')):
             root, objects = extract_from_xml(xml_file)
             im_w, im_h = int(root.find('size')[0].text), int(
                 root.find('size')[1].text)
-            im_filename = root.find('filename').text.split('.')[0]
-            extn = root.find('filename').text.split('.')[1]
+            im_filename = os.path.splitext(root.find('filename').text)[0]
+            extn = os.path.splitext(root.find('filename').text)[1]
             if number_tiles > 0:
                 n_cols, n_rows = calc_columns_rows(number_tiles)
                 tile_w = int(floor(im_w / n_cols))
@@ -313,7 +318,7 @@ class Slicer(object):
 
             for tile in tiles:
                 img_no_str = '{:06d}'.format(img_no)
-                voc_writer = Writer('{}.{}'.format(img_no_str, extn), tile_w, tile_h)
+                voc_writer = Writer('{}{}'.format(img_no_str, extn), tile_w, tile_h)
                 for obj in objects:
                     obj_lbl = obj[-4:]
                     points_info = which_points_lie(obj_lbl, tile)
@@ -368,7 +373,7 @@ class Slicer(object):
                     self._ignore_tiles.append(img_no_str)
                 else:
                     voc_writer.save(
-                        '{}{}{}.xml'.format(self.ANN_DST, os.sep, img_no_str))
+                        '{}{}{}.xml'.format(self.ANN_DST, separator, img_no_str))
                     tile_ids.append(img_no_str)
                     img_no += 1
                 empty_count = 0
@@ -469,9 +474,9 @@ class Slicer(object):
     def __resize_images(self, new_size, resample, resize_factor):
         """Private Method
         """
-        for file in sorted(glob.glob(self.IMG_SRC + os.sep + "*")):
-            file_name = file.split(os.sep)[-1].split('.')[0]
-            file_type = file.split(os.sep)[-1].split('.')[-1].lower()
+        for file in sorted(glob.glob(self.IMG_SRC + separator + "*")):
+            file_name = file.split(separator)[-1].split('.')[0]
+            file_type = file.split(separator)[-1].split('.')[-1].lower()
             if file_type not in IMG_FORMAT_LIST:
                 continue
             im = Image.open(file)
@@ -482,7 +487,7 @@ class Slicer(object):
                 new_size = tuple(new_size)
 
             new_im = im.resize(size=new_size, resample=resample)
-            new_im.save('{}{}{}.{}'.format(self.IMG_DST, os.sep, file_name, file_type))
+            new_im.save('{}{}{}.{}'.format(self.IMG_DST, separator, file_name, file_type))
 
     def resize_bboxes_by_size(self, new_size):
         """Resizes bounding box annotations in the source directory to specified size `new_size`.
@@ -517,13 +522,13 @@ class Slicer(object):
     def __resize_bboxes(self, new_size, resize_factor):
         """Private Method
         """
-        for xml_file in sorted(glob.glob(self.ANN_SRC + os.sep + '*.xml')):
+        for xml_file in sorted(glob.glob(self.ANN_SRC + separator + '*.xml')):
             root, objects = extract_from_xml(xml_file)
             im_w, im_h = int(root.find('size')[0].text), int(
                 root.find('size')[1].text)
-            im_filename = root.find('filename').text.split('.')[0]
-            an_filename = xml_file.split(os.sep)[-1].split('.')[0]
-            extn = root.find('filename').text.split('.')[1]
+            im_filename = os.path.splitext(root.find('filename').text)[0]
+            an_filename = xml_file.split(separator)[-1].split('.')[0]
+            extn = os.path.splitext(root.find('filename').text)[1]
             if resize_factor is None:
                 w_scale, h_scale = new_size[0]/im_w, new_size[1]/im_h
             else:
@@ -534,7 +539,7 @@ class Slicer(object):
                 new_size = tuple(new_size)
 
             voc_writer = Writer(
-                '{}.{}'.format(im_filename, extn), new_size[0], new_size[1])
+                '{}{}'.format(im_filename, extn), new_size[0], new_size[1])
 
             for obj in objects:
                 obj_lbl = list(obj[-4:])
@@ -545,7 +550,7 @@ class Slicer(object):
 
                 voc_writer.addObject(obj[0], obj_lbl[0], obj_lbl[1], obj_lbl[2], obj_lbl[3],
                                      obj[1], obj[2], obj[3])
-            voc_writer.save('{}{}{}.xml'.format(self.ANN_DST, os.sep, an_filename))
+            voc_writer.save('{}{}{}.xml'.format(self.ANN_DST, separator, an_filename))
 
     def visualize_sliced_random(self, map_dir=None):
         """Picks an image randomly and visualizes unsliced and sliced images using `matplotlib`.
@@ -567,9 +572,9 @@ class Slicer(object):
         mapping = ''
 
         if map_dir is None:
-            map_path = self.IMG_DST + os.sep + 'mapper.csv'
+            map_path = self.IMG_DST + separator + 'mapper.csv'
         else:
-            map_path = map_dir + os.sep + 'mapper.csv'
+            map_path = map_dir + separator + 'mapper.csv'
         with open(map_path) as src_map:
             read_csv = csv.reader(src_map, delimiter=',')
             # Skip the header
@@ -593,8 +598,8 @@ class Slicer(object):
         None
             However, displays the final plots.
         """
-        im_file = random.choice(list(glob.glob('{}{}*'.format(self.IMG_SRC, os.sep))))
-        file_name = im_file.split(os.sep)[-1].split('.')[0]
+        im_file = random.choice(list(glob.glob('{}{}*'.format(self.IMG_SRC, separator))))
+        file_name = im_file.split(separator)[-1].split('.')[0]
 
         plot_image_boxes(self.IMG_SRC, self.ANN_SRC, file_name)
         plot_image_boxes(self.IMG_DST, self.ANN_DST, file_name)


### PR DESCRIPTION
spliting filenames using .split() results in multiple word filenames, so it fails to pick full filename
replaced .split with os.path.splitext
see issue #8